### PR TITLE
Fix code for Pytorch 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PyTorch implementation of a Self-Organizing Map. The code is adapted from Sachin
 
 ### Requirements
 Code is written in Python 3.6 and requires:
-* PyTorch 0.3
+* PyTorch 1.0.0
 
 ### Run the example
 Use the following command:

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ for i, loc in enumerate(locations):
 image_grid = centroid_grid
 
 #Map colours to their closest neurons
-mapped = som.map_vects(colors)
+mapped = som.map_vects(torch.Tensor(colors))
 
 #Plot
 plt.imshow(image_grid)


### PR DESCRIPTION
In Pytorch 1.0.0, color vector needs to be a Tensor.